### PR TITLE
Hotfix: Prevent auto-login after face recognition

### DIFF
--- a/web/templates/face_login.html
+++ b/web/templates/face_login.html
@@ -121,10 +121,6 @@
                     storedSuggestions = data.suggestions || [];
                      suggestionsDiv.style.display = "none";
 
-                    // Redirect after a short delay
-                     setTimeout(() => {
-                         window.location.href = data.redirect;
-                     }, 1500);
                  } else {
                     // If not recognized
                      statusText.textContent = "User not recognized.";


### PR DESCRIPTION
This fix removes the automatic redirection after successful face recognition.
Now, the user must explicitly confirm their identity by clicking the "Confirm" button before being redirected.