### PR TITLE
Reload recognizer embeddings after saving new user embedding

### DIFF
--- a/web/routes/face_routes.py
+++ b/web/routes/face_routes.py
@@ -21,6 +21,7 @@ from datetime import datetime
 # === Custom Modules ===
 from generate_multiple_embeddings_m import EmbeddingGenerator
 from utils.user_db import load_users, save_users
+from web.routes.auth_routes import recognizer
 
 # === Data processing and security ===
 import base64
@@ -136,6 +137,9 @@ def save_embedding():
     os.makedirs(path, exist_ok=True)
     with open(os.path.join(path, f"{folder}_{index:02d}.pkl"), "wb") as f:
         pickle.dump(embedding, f)
+
+    # Update global recognizer embeddings
+    recognizer.known_embeddings = recognizer.load_known_embeddings()
 
     return "Saved successfully", 200
 


### PR DESCRIPTION
Added logic to reload recognizer.known_embeddings after saving a new .pkl file,
ensuring newly created users are recognized immediately without restarting the app.

Closes #21
