### PR TITLE
Reload embeddings after user deletion

### DIFF
--- a/web/routes/admin_routes.py
+++ b/web/routes/admin_routes.py
@@ -18,6 +18,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, sessio
 
 # === Internal helper functions to read/write users from JSON file ===
 from utils.user_db import load_users, save_users
+from web.routes.auth_routes import recognizer
 
 # === Password hashing and file system handling ===
 import bcrypt  # Secure password hashing
@@ -140,6 +141,10 @@ def admin_remove():
         if os.path.exists(folder_path):
             shutil.rmtree(folder_path)
             print(f"[INFO] Pasta de embeddings {folder_path} removida")
+
+                # Reload embeddings in the global face recognizer
+        recognizer.known_embeddings = recognizer.load_known_embeddings()
+        print("[DEBUG] Embeddings recarregados após remoção do utilizador")
     else:
         print("[WARN] Nenhum utilizador encontrado com o folder fornecido")
 


### PR DESCRIPTION
This PR addresses issue #40, fixing the problem where deleted users still appeared and were recognized in the login screen until the app was restarted.

Summary
The FaceRecognizer instance (recognizer) was holding embeddings in memory.
After deleting a user and removing their embedding folder, we now reload the embeddings immediately.
This ensures the deleted user no longer appears or is recognized without needing to restart the app.

Closes #40 